### PR TITLE
Feature requests - duplicate estimation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,13 +17,13 @@ Hi-C connectivity drops off in approximately a power-law with increasing linear 
 
 For installation, run this statement in a terminal:
 
+`git clone https://github.com/phasegenomics/bam_to_mate_hist.git && cd bam_to_mate_hist && sh setup.sh`
+
+if that doesn't work, you can try to just install the requirements, which leaves out some details in the PDF report but otherwise is functionally equivalent.
+
 `git clone https://github.com/phasegenomics/bam_to_mate_hist.git && cd bam_to_mate_hist && pip install --user -r requirements.txt`
 
-We include a `requirements.txt` file with these dependencies, which should be installed if you use the above command. However, if you want to use the PDF report feature of this tool, you will need to install `wkhtmltopdf` externally, as we cannot install this readily.
-
-The dependencies could also be installed with pip, e.g.:
-
-`pip install pysam`
+We include a `requirements.txt` file with dependencies, which should be installed if you use the above command. However, if you want to use the PDF report feature of this tool, you will need to install `wkhtmltopdf` externally, as we cannot install this readily.
 
 I've tested this script on MacOSX, Ubuntu Linux, and Amazon Linux. 
 
@@ -47,12 +47,13 @@ To set the name of the files written out, such as the PNG figures and the report
 ## Interpreting results
 Histogram plots should show some characteristic features:
 * Substantial long-range contacts (note that contact distance is bounded by the assembly). You will want to see at least some contacts approximately as long as your longest contig. 
-* Gradual drop-off in signal with increasing distance (in log space). Choppiness or spikes in the distribution may indicate problems, unless it can be attributed to sampling error due to (very) small numbers of reads. Periodicity in the distribution with distance often indicates problems.
+* Gradual drop-off in signal with increasing distance (in log space). Choppiness or spikes in the distribution may indicate problems such as collapsed repeats or chimerisms, unless it can be attributed to sampling error due to (very) small numbers of reads. Periodicity in the distribution with distance often indicates problems.
 * The leftmost spike of mates mapping very close is always the most prominent feature in the plot. However, it should not be too much larger than the rest of the distribution, or you are not having enough long-distance contacts. A dropoff of 3-4 orders of magnitude in the 0-20KB plot is the most you want to see in that sudden dropoff. Ideally it would be only 1-2 orders of magnitude dropoff in the 0-20KB range.
+
 ### Statistics reported
 * Number of read pairs with mates mapping to exactly the same position (distance == 0). These are bad. We observe these reads at some rate all the time, but they are especially abundant when there is a problem. This proportion should be small, no more than 10% and ideally much smaller. That said, if other measures look ok it might be worth trying a library even if there are many distance == 0 pairs.
-* Number of read pairs with mates mapping >10KB apart. These are good. We would ideally like to see lots of very long-distance contacts between mates, as that is a sign of strong Hi-C signal. On the order of 0.5-5% is reasonable, though it depends on the assembly.
-* Number of read pairs with mates mapping to different contigs/chromosomes. These are good if they represent contacts within a cell, but bad if they represent noise or contacts between cells (e.g. for metagenomic data). On the order of 5-20% seems standard, again it depends on particulars of the assembly.
+* Number of read pairs with mates mapping >10KB apart. These are good. We would ideally like to see lots of very long-distance contacts between mates, as that is a sign of strong Hi-C signal. On the order of 1-20% is reasonable, though it depends on the assembly. For scaffolding best results are obtained when this is higher than 5%.
+* Number of read pairs with mates mapping to different contigs/chromosomes. These are good if they represent contacts within a cell, but bad if they represent noise or contacts between cells (e.g. for metagenomic data). On the order of 10-40% seems standard, again it depends on particulars of the assembly. 
 * Number of split reads. These are good, usually, as they hopefully represent Hi-C junctions and thus successful Hi-C. There are of course other reasons why a read might be split.
 
 ### Example histograms
@@ -64,3 +65,4 @@ Problems observed in QC may indicate an issue either with the Hi-C reads or the 
 * If the issue is the reads, you can try filtering your read alignments, either removing bad contigs or low-confidence reads. Our tool `matlock` has utilities for doing this. 
 * If the issue is the assembly, you can either get a new/more appropriate assembly somehow, or you can attempt to fix your existing assembly. 
 * The best way to fix assemblies in our experience is to break up chimerically assembled contigs. This can be achieved by either breaking on gaps if they exist in your assembly (e.g. runs of Ns) under the assumption that most chimerae span such gaps, or by directly inferring and breaking misjoins in your assembly. Breaking on gaps is fairly trivial, and our tool `polar_star` can help you infer and break misjoins using long read data. 
+* If the issue is that you simply don't have enough long-distance Hi-C contacts, **unavoidably you will sometimes have to remake the Hi-C library**.

--- a/bam_to_mate_hist.py
+++ b/bam_to_mate_hist.py
@@ -460,6 +460,8 @@ def extract_stats(stat_dict, bamfile, outfile_name, count_diff_refname_stub=Fals
     out_dict["NUM_DUPE_READS"] = float(out_dict["NUM_DUPE_READS"]) / 2.
     out_dict["MAPQ0_READS"] = float(out_dict["MAPQ0_READS"]) / 2.
     out_dict['NUM_DUPE_READS_EXTRAP'] = float("{:.3f}".format(stat_dict["NUM_DUPE_READS_EXTRAP"]))
+    out_dict['TARGET_READ_TOTAL'] = stat_dict['TARGET_READ_TOTAL']
+    out_dict['NUM_READS'] = num_pairs
 
     print "Number of contigs (more is harder):"
     print stat_dict["NUM_CONTIGS"]
@@ -491,7 +493,7 @@ def extract_stats(stat_dict, bamfile, outfile_name, count_diff_refname_stub=Fals
     print "Count of duplicate reads (duplicates are bad; WILL ALWAYS BE ZERO UNLESS BAM FILE IS PREPROCESSED TO SET THE DUPLICATES FLAG):"
     print stat_dict["NUM_DUPE_READS"], "of total", num_pairs * 2, ", fraction ", out_dict["NUM_DUPE_READS"]
 
-    print 'Duplicate fraction at {} reads: {:.3f}'.format(stat_dict['TARGET_READ_TOTAL'], stat_dict['NUM_DUPE_READS_EXTRAP'])
+    print 'Duplicate fraction at {} reads: {:.3f}'.format(stat_dict['TARGET_READ_TOTAL'], out_dict['NUM_DUPE_READS_EXTRAP'])
 
     #stat_dict["NUM_READS_NEEDED"] = estimate_required_num_reads(stat_list[0], num_pairs=num_pairs, refs=refs, target=600)
     #print "Number of reads needed for informative scaffolding, estimated based on sample:"
@@ -529,6 +531,8 @@ def write_stat_table(stat_dict, outfile_name):
                      "diff_contig_pairs\t{NUM_DIFF_CONTIG_PAIRS}\n" \
                      "split_reads\t{NUM_SPLIT_READS}\n" \
                      "dupe_reads\t{NUM_DUPE_READS}\n"  \
+                     "dupe_reads_extrapolated\t{NUM_DUPE_READS_EXTRAP}\n" \
+                     "total_reads_extrapolated\t{TARGET_READ_TOTAL}\n" \
                      "n50\t{N50}\n" \
                      "num_contigs\t{NUM_CONTIGS}\n" \
                      "greater_10k_contigs\t{GREATER_10K_CONTIGS}\n" \

--- a/bam_to_mate_hist.py
+++ b/bam_to_mate_hist.py
@@ -236,7 +236,9 @@ def make_pdf_report(qc_repo_path, stat_dict, outfile_name):
         'no-outline': None
     }
 
-    template_path = os.path.join(qc_repo_path, "collateral", "HiC_QC_report_template.md")
+    template_path = os.path.join(qc_repo_path, "collateral", "HiC_QC_report_template_versioned.md")
+    if not os.path.exists(template_path):
+        template_path = os.path.join(qc_repo_path, "collateral", "HiC_QC_report_template.md")
     style_path = os.path.join(qc_repo_path, "collateral", "style.css")
     if not os.path.exists(template_path):
         UserWarning("can't find markdown template at {0}! skipping making template.".format(

--- a/collateral/HiC_QC_report_template.md
+++ b/collateral/HiC_QC_report_template.md
@@ -28,7 +28,7 @@
 See below for information on differences between Phase Genomics Hi-C libraries and traditional Hi-C libraries.
 
 
-</div class="page">
+<div class="page"/>
 
 ## Aligned mate distance histograms
 !["Long range interaction histogram"]({PATH_TO_LONG_HIST})

--- a/collateral/HiC_QC_report_template.md
+++ b/collateral/HiC_QC_report_template.md
@@ -51,3 +51,6 @@ We therefore rely more heavily on metrics that directly relate to the usefulness
 **IMPORTANT NOTE: THE DUPLICATE FLAG IS NOT SET BY DEFAULT IN A BAM FILE. YOU NEED TO EXPLICITLY SET IT BY E.G. RUNNING SAMBLASTER ON YOUR BAM FILE. IF THE FRACTION OF DUPLICATES IS EXACTLY ZERO, IT PROBABLY MEANS THAT THE FLAG HAS NOT BEEN SET.**
 
 Sequencing libraries frequently contain duplicate reads, due to PCR or optical issues. These are generally considered to be non-informative, and are thus bad. Higher proportions of duplicate reads are also correlated with low library complexity and poor library performance generally.
+
+#### REPORT VERSION: COMMIT_VERSION
+

--- a/collateral/HiC_QC_report_template.md
+++ b/collateral/HiC_QC_report_template.md
@@ -18,13 +18,17 @@
 | Fraction of split reads                                         | {NUM_SPLIT_READS}       | 0.01-0.1 (PG libraries) 0.3+ (other libraries) |
 | Fraction of zero-distance pairs                                 | {ZERO_DIST_PAIRS}       | 0-0.2                                        |
 | Fraction of reads with zero map quality                         | {MAPQ0_READS}           | 0-0.1                                        |
-| Fraction of duplicate reads*                                 | {NUM_DUPE_READS}           | 0-0.1                                        |
+| Fraction of duplicate reads*                                    | {NUM_DUPE_READS}        | 0-0.1                                        |
+| (SUBJECTIVE!!) Hi-C library judgement                           | {JUDGEMENT}             | pass/fail/mixed-results/low-signal                                        |
 
 
 </center>
 *If this quantity is zero, see duplicate read section below.
 
 See below for information on differences between Phase Genomics Hi-C libraries and traditional Hi-C libraries.
+
+
+<div class="page"/>
 
 ## Aligned mate distance histograms
 !["Long range interaction histogram"]({PATH_TO_LONG_HIST})

--- a/collateral/HiC_QC_report_template.md
+++ b/collateral/HiC_QC_report_template.md
@@ -23,26 +23,29 @@
 | (SUBJECTIVE!!) Hi-C library judgement                           | {JUDGEMENT}             | pass/fail/mixed-results/low-signal           |
 </center>
 
-\*If this quantity is zero, see duplicate read section below.
+*If this quantity is zero, see duplicate read section below. If quantity is negative, there are too few reads sampled to estimate duplicates.
 
 See below for information on differences between Phase Genomics Hi-C libraries and traditional Hi-C libraries.
 
 
-<div class="page"/>
-
 ## Aligned mate distance histograms
+
 !["Long range interaction histogram"]({PATH_TO_LONG_HIST})
 !["Short range interaction histogram"]({PATH_TO_SHORT_HIST})
 
 ## Duplicate read saturation curve
+
 !["Duplicate read saturation curve"]({PATH_TO_DUP_SAT})
 
 ## Alignment distance statistics and plots
 We briefly describe some of the statistics we compute below to aid interpretation of this report.
+
 ### Fraction of read pairs > 10KB apart
 More is better.
+
 ### Fraction of read pairs mapping to different contigs or chromosomes
 More is better.
+
 ### Fraction of zero-distance pairs
 Less is better. Seems to be due to very short library inserts or sometimes mapping artifacts; can be an issue on some Illumina instruments such as iSeq and HiSeqX. Still, even libraries with up to 70% zero-distance pairs can yield usable results sometimes.
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/sh
 COMMIT_VERSION=`git rev-parse HEAD`
-sed s/COMMIT_VERSION/$COMMIT_VERSION/g < collateral/HiC_QC_report_template.md > collateral/HiC_QC_report_template_versioned.md
+#sed s/COMMIT_VERSION/$COMMIT_VERSION/g < collateral/HiC_QC_report_template.md > collateral/HiC_QC_report_template_versioned.md
+echo $COMMIT_VERSION > collateral/commit_id
 pip install --user -r requirements.txt
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/sh
+COMMIT_VERSION=`git rev-parse HEAD`
+sed s/COMMIT_VERSION/$COMMIT_VERSION/g < collateral/HiC_QC_report_template.md > collateral/HiC_QC_report_template_versioned.md
+pip install --user -r requirements.txt
+

--- a/test_bam_to_mate_hist.py
+++ b/test_bam_to_mate_hist.py
@@ -25,7 +25,7 @@ class MyTestCase(unittest.TestCase):
         num_reads = 1000
         bamfile = "collateral/abc_test.bam"
         count_diff_refname_stub = False
-        self.stat_dict = b2mh.parse_bam_file(
+        self.stat_dict, total_reads, num_dupes = b2mh.parse_bam_file(
             num_reads=num_reads, bamfile=bamfile, count_diff_refname_stub=count_diff_refname_stub)
 
         self.example_read = pysam.AlignedSegment()
@@ -39,7 +39,6 @@ class MyTestCase(unittest.TestCase):
         self.example_read.set_tag("MD", 100)
         self.example_read.set_tag("AS", 100)
         self.example_read.set_tag("XS", 0)
-
 
     def tearDown(self):
         pass


### PR DESCRIPTION
- Brad added saturation curve estimation for duplicates. This includes both the estimation, the addition to the report, and plotting.
- I fixed a bug wherein curve estimation divided by zero for small read counts by testing for that and skipping estimation in these cases. I added some behavior for plotting/reporting to handle these cases. (This bug showed up because the script crashed on the test dataset, which is of course very small.)
- I changed how reports were versioned to get rid of the weird report no-plotting bug that was introduced by sed somehow. 
- Made a couple of minor changes to template. 
- I altered the unit tests so they could handle changes to `parse_bam_file()`.