### PR TITLE
Pretty report numbers

### DIFF
--- a/bam_to_mate_hist.py
+++ b/bam_to_mate_hist.py
@@ -306,15 +306,14 @@ def html_from_judgement(good, bad):
             ValueError: if impossible logical situations occur given two bools.
 
     '''
-
     if good and not bad:
-        return '<span style="background-color:green">PASS</span>'
+        return '<span class="pass">PASS</span>'
     elif not good and bad:
-        return '<span style="background-color:red">FAIL</span>'
+        return '<span class="fail">FAIL</span>'
     elif good and bad:
-        return '<span style="background-color:yellow">MIXED RESULTS</span>'
+        return '<span class="mixed-results">MIXED RESULTS</span>'
     elif not good and not bad:
-        return '<span style="background-color:yellow">LOW SIGNAL</span>'
+        return '<span class="low-signal">LOW SIGNAL</span>'
     else:
         raise ValueError("logical impossibility!")
 

--- a/bam_to_mate_hist.py
+++ b/bam_to_mate_hist.py
@@ -467,7 +467,7 @@ def make_pretty_stat_dict(stat_dict):
                 if float(v) == -0.0:
                     ret[k] = '0.0%'
                 else:
-                    ret[k] = '{0}%'.format(round(10000.0*float(v)) / 100.0)
+                    ret[k] = '{0}%'.format(round(100.0*float(v), 2))
         else:
             ret[k] = v
     return ret

--- a/collateral/HiC_QC_report_template.md
+++ b/collateral/HiC_QC_report_template.md
@@ -10,29 +10,28 @@
 | BAM file                                                        | {BAM_FILE_PATH}         | N/A                                           |
 | Assembly size                                                   | {TOTAL_LEN}             | N/A                                           |
 | Contig N50                                                      | {N50}                   | N/A                                           |
-| Number of contigs                                               | {NUM_CONTIGS}           | N/A                                           |
-| Number of contigs greater than 10KB                             | {GREATER_10K_CONTIGS}   | N/A                                           |
-| Number of read pairs analyzed                                   | {NUM_PAIRS}             | N/A                                           |
-| Fraction of read pairs >10KB apart                              | {NUM_10KB_PAIRS}        | 0.01-0.15                                    |
-| Fraction of read pairs >10KB apart mapping to contigs >10Kbp    | {LARGE_INSERT_PROPORTION} | 0.01-0.15                                   |
-| Fraction of read pairs mapping to different contigs/chromosomes | {NUM_DIFF_CONTIG_PAIRS} | 0.1-0.6 (contigs)<br>0.01-0.2 (chromosomes)      |
-| Fraction of split reads                                         | {NUM_SPLIT_READS}       | 0.01-0.1 (PG libraries) 0.3+ (other libraries) |
-| Fraction of zero-distance pairs                                 | {ZERO_DIST_PAIRS}       | 0-0.2                                        |
-| Fraction of reads with zero map quality                         | {MAPQ0_READS}           | 0-0.1                                        |
-| Fraction of duplicate reads*                                    | {NUM_DUPE_READS}        | 0-0.1                                        |
-| Fraction of duplicate reads (extrapolated to {TARGET_READ_TOTAL} reads)* | {NUM_DUPE_READS_EXTRAP} | 0-0.5                               |
-| (SUBJECTIVE!!) Hi-C library judgement                           | {JUDGEMENT}             | pass/fail/mixed-results/low-signal           |
+| Contigs                                               | {NUM_CONTIGS}           | N/A                                           |
+| Contigs greater than 10kbp                             | {GREATER_10K_CONTIGS}   | N/A                                           |
+| Total read pairs analyzed                                   | {NUM_PAIRS}             | N/A                                           |
+| Read pairs >10kbp apart                              | {NUM_10KB_PAIRS}        | 1-15%                                    |
+| Read pairs >10kbp apart on contigs >10kbp    | {LARGE_INSERT_PROPORTION} | 1-15%                                   |
+| Read pairs mapping to different contigs/chromosomes | {NUM_DIFF_CONTIG_PAIRS} | 10-60% (contigs)<br>1-20% (chromosomes)      |
+| Split reads                                         | {NUM_SPLIT_READS}       | 1-10% (PG libraries)<br> 30%+ (other libraries) |
+| Zero-distance pairs                                 | {ZERO_DIST_PAIRS}       | 0-20%                                        |
+| Zero map quality reads                         | {MAPQ0_READS}           | 0-10%                                        |
+| Duplicate reads*                                    | {NUM_DUPE_READS}        | 0-10%                                        |
+| Duplicate reads (extrapolated to {TARGET_READ_TOTAL} reads)* | {NUM_DUPE_READS_EXTRAP} | 0-50%                               |
+| Subjective Hi-C library judgement                           | {JUDGEMENT}             | see below           |
 </center>
 
-*If this quantity is zero, see duplicate read section below. If quantity is negative, there are too few reads sampled to estimate duplicates.
-
+*If this quantity is zero, see duplicate read section below. If negative, there are too few reads sampled to estimate duplicates.
 See below for information on differences between Phase Genomics Hi-C libraries and traditional Hi-C libraries.
-
 
 ## Aligned mate distance histograms
 
 !["Long range interaction histogram"]({PATH_TO_LONG_HIST})
 !["Short range interaction histogram"]({PATH_TO_SHORT_HIST})
+
 !["Log-log interaction histogram"]({PATH_TO_LOG_LOG_HIST})
 
 ## Duplicate read saturation curve
@@ -42,28 +41,46 @@ See below for information on differences between Phase Genomics Hi-C libraries a
 ## Alignment distance statistics and plots
 We briefly describe some of the statistics we compute below to aid interpretation of this report.
 
-### Fraction of read pairs > 10KB apart
-More is better.
+### Subjective Hi-C Library Judgement
+While Hi-C data is nuanced and some analyses are more sensitive to data quality than others,  a basic quality assessment can usually be made by examining the mapping characteristics of the Hi-C library. Based on our experience working with Hi-C data, we classify libraries into one of four QC categories:
 
-### Fraction of read pairs > 10KB apart mapping to contigs >10Kbp
-More is better. Attempts to correct for assembly contiguity.
+- **Pass** means that from everything we can tell, the library looks to be in great shape. Proceed to full sequencing or analysis with confidence.
 
-### Fraction of read pairs mapping to different contigs or chromosomes
-More is better.
+- **Mixed Results** means that the library is good in some ways, but not in others. Perhaps it has a good amount of long range data, but there are also an elevated number of read pairs with MAPQ 0. Usually, data generated from Mixed Results libraries works out just fine (a high MAPQ 0 number can be due to repetitiveness in the assembly, for example), but it is good to know there may have been a few hiccups in the library prep in case troubleshooting is needed down the line.
 
-### Fraction of zero-distance pairs
-Less is better. Seems to be due to very short library inserts or sometimes mapping artifacts; can be an issue on some Illumina instruments such as iSeq and HiSeqX. Still, even libraries with up to 70% zero-distance pairs can yield usable results sometimes.
+- **Low Signal** means that the library contains good Hi-C signal, but it's in lower proportion than usual. These libraries are generally good for generating useful Hi-C data, but you may need to sequence a little deeper than normal to get enough of it. You might consider size selecting the library to discard reads outside the 300-700bp range, as these are unlikely to be good Hi-C junctions. Alternatively, you might just want to prep a new library.
+
+- **Fail** means that the library, or perhaps the library in combination with a low-contiguity or error-prone assembly, does not look useful. Sometimes size selection can rescue such libraries, but sometimes a new prep is the only way forward. (Contact us)[mailto:support@phasegenomics.com] if you get a fail and we will help you out.
+
+### Read pairs > 10kbp apart
+These are the proportion of read pairs which map to the same contig, with at least 10kbp separating them. More is always better, but because this number is affected by assembly contiguity, there is not a specifc target threshold. Note that for some analyses, such as scaffolding or metagenomic deconvolution, read pairs that map to the same contig are not useful because they do not provide information that the assembly doesn't already contain. This statistic is more useful for these projects because it correlates with library prep success. These reads are useful for analyses like structural variant analysis or assembly misjoin detection, because they provide detailed structural information about existing assembled sequences.
+
+### Read pairs > 10kbp apart mapping to contigs >10kbp
+These are the proportion of read pairs which map to the same contig, with at least 10kbp separating them, but only considering read pairs mapping to contigs that are at least 10kbp long. This attempts to corrects for assembly contiguity differences. More is always better, but typically at least 5% is desired. Note that for some analyses, such as scaffolding or metagenomic deconvolution, read pairs that map to the same contig are not useful because they do not provide information that the assembly doesn't already contain. This statistic is more useful for these projects because it correlates with library prep success. These reads are useful for analyses like structural variant analysis or assembly misjoin detection, because they provide detailed structural information about existing assembled sequences.
+
+
+### Read pairs mapping to different contigs or chromosomes
+These are the proportion of read pairs which map to different contigs, which is particularly important . More is always better, but because this number is affected by assembly quality, there is not a specifc target threshold, although at least 20% on *de novo* assembly projects is helpful. These reads are the primary source of information for Hi-C scaffolding or metagenomic deconvolution analyses. This statistic useful on most *de novo* proects because it also correlates with library prep success. These reads may be useful for analyses like structural variant analysis or assembly misjoin detection if those are performed on lower contiguity assemblies, because they provide detailed structural information about sequences which were not assembled together into contigs.
+
+
+### Zero-distance pairs
+A failure mode for Hi-C libraries is a large number of read pairs which map as if there were no distance between them. This can occur for many reasons, but common ones include very short library inserts (possible overdigestion) or sometimes mapping artifacts. These can also be an issue on some Illumina instruments such as iSeq and HiSeqX. These essentially represent read pairs which provide no long-range interaction information. Less is always better for these kinds of read pairs, although even libraries with up to 70-80% zero-distance pairs can yield usable results.
+
 
 ### Split reads
-Traditionally, split reads have been a favored measure of Hi-C library quality. This is because traditional Hi-C library preparations are expected to produce many reads reading through junctions.
+Traditionally, split reads have been a favored measure of Hi-C library quality because they directly exhibit Hi-C junctions. Most traditional Hi-C library preparations produce many reads that sequence through junctions because their Hi-C junctions tend to occur randomly on the proximity ligated chimeric molecules. However, Phase Genomics has introduced steps into our protocol which tend to make junctions occur closer to the center of the proximity ligated chimeric molecules.  
 
-Phase Genomics libraries, whether produced in our laboratory or by means of ProxiMeta &copy;, Animal, Plant, or Human kits, will have a generally lower fraction of split reads. This is because we have optimized our Hi-C protocol to enrich for slightly longer fragments around Hi-C junctions, such that each read is less likely to read through a junction even when a junction is present. This innovation improves mappability.
+Phase Genomics libraries, whether produced in our laboratory or by means of our Plant, Animal, Human, or Microbe Hi-C kits, will have a generally lower fraction of split reads. This is because we have optimized our Hi-C protocol to enrich for slightly longer fragments around Hi-C junctions, such that each read is less likely to read through a junction even when a junction is present.
 
-We therefore rely more heavily on metrics that directly relate to the usefulness of Hi-C reads for proximity analysis, such as the percentage of read pairs with mates mapping far away, or mapping to different contigs.
+This innovation improves mappability and increases the amount of useful data, and reduces the utility of split read measurements to assess library quality. We therefore rely more heavily on metrics that directly relate to the usefulness of Hi-C reads for proximity analysis, such as the percentage of read pairs with mates mapping far away, or mapping to different contigs.
 
 ### Duplicate reads
 **IMPORTANT NOTE: THE DUPLICATE FLAG IS NOT SET BY DEFAULT IN A BAM FILE. YOU NEED TO EXPLICITLY SET IT BY E.G. RUNNING SAMBLASTER ON YOUR BAM FILE. IF THE FRACTION OF DUPLICATES IS EXACTLY ZERO, IT PROBABLY MEANS THAT THE FLAG HAS NOT BEEN SET.**
 
-Sequencing libraries frequently contain duplicate reads, due to PCR or optical issues. These are generally considered to be non-informative, and are thus bad. Higher proportions of duplicate reads are also correlated with low library complexity and poor library performance generally.
+Sequencing libraries frequently contain duplicate reads due to PCR or optical issues. These are generally considered to be non-informative because they are chemical artifacts rather than biological signal, and are thus typically excluded from further analysis. Higher proportions of duplicate reads are also correlated with low library complexity and poor library performance, making the proportion of duplicate reads a useful quality control measure.
 
-#### REPORT VERSION: COMMIT_VERSION
+Also, because we often recommend sequencing a few million read pairs for QC prior to a full sequencing run, it is helpful to project the amount of duplicate reads a full run might generate. To do this, we attempt to fit a curve to the rate at which duplicates are observed in a library, and then project the proportion of duplicates that would be expected in a deeper sequencing run. This projection is a reasonably useful heuristic, but it is not a guarantee that the true duplicate rate will be near a specific value. QC sequencing data with a very low number of reads or which mapped well at a very low rate can distort this calculation. We attempt to identify low confidence calculations and report that we could not extrapolate the expected duplicate frequency when it is possible to do so. 
+<br>
+<h4 class="centered">
+REPORT VERSION: COMMIT_VERSION
+</h4>

--- a/collateral/style.css
+++ b/collateral/style.css
@@ -4,38 +4,66 @@ html {
   -webkit-text-size-adjust:100%;
   -ms-text-size-adjust:100%
 }
- 
+
 body {
   margin:0;
 }
- 
+
 h1,
 .h1 {
   font-size: 24px;
 }
- 
+
 h2,
 .h2 {
-  font-size: 18px;
+  font-size: 20px;
 }
- 
-h3,
-.h3 {
+
+h3, h4, h5, h6, p {
+  text-align: left;
+  margin-left: 30px;
+  margin-right: 30px;
+}
+
+h3 {
+  font-size: 16px;
+}
+
+h4 {
   font-size: 14px;
 }
  
-h4,
-.h4 {
+h5 {
   font-size: 12px;
 }
  
-h5,
-.h5 {
+h6 {
   font-size: 11px;
 }
- 
-h6,
-.h6 {
-  font-size: 9px;
+
+p {
+  font-size: 14px;
+}
+
+.centered {
+  text-align: center;
+}
+
+.pass, .fail, .low-signal, .mixed-results {
+  padding: 3px 6px;
+  font-weight: bold;
+  color: white;
+}
+
+.pass {
+  background-color: green;
+}
+
+.fail {
+  background-color: red;
+}
+
+.low-signal, .mixed-results {
+  background-color: orange;
 }
 

--- a/test_bam_to_mate_hist.py
+++ b/test_bam_to_mate_hist.py
@@ -90,7 +90,168 @@ class MyTestCase(unittest.TestCase):
     def test_is_split_read_true(self):
         self.example_read.set_tag("SA", 1)
         self.assertTrue(b2mh.is_split_read(self.example_read))
-
+    
+    def test_represents_number(self):
+        self.assertTrue(b2mh.represents_number(5))
+        self.assertTrue(b2mh.represents_number(0))
+        self.assertTrue(b2mh.represents_number(-5))
+        self.assertTrue(b2mh.represents_number('5'))
+        self.assertTrue(b2mh.represents_number('0'))
+        self.assertTrue(b2mh.represents_number('-5'))
+        self.assertTrue(b2mh.represents_number('+5'))
+        
+        self.assertTrue(b2mh.represents_number(5.0))
+        self.assertTrue(b2mh.represents_number(0.0))
+        self.assertTrue(b2mh.represents_number(-5.0))
+        self.assertTrue(b2mh.represents_number('5.0'))
+        self.assertTrue(b2mh.represents_number('0.0'))
+        self.assertTrue(b2mh.represents_number('-5.0'))
+        self.assertTrue(b2mh.represents_number('+5.0'))
+        
+        self.assertTrue(b2mh.represents_number(5.2))
+        self.assertTrue(b2mh.represents_number(0.2))
+        self.assertTrue(b2mh.represents_number(-5.2))
+        self.assertTrue(b2mh.represents_number('5.2'))
+        self.assertTrue(b2mh.represents_number('0.2'))
+        self.assertTrue(b2mh.represents_number('-5.2'))
+        self.assertTrue(b2mh.represents_number('+5.2'))
+        
+        self.assertFalse(b2mh.represents_number('a'))
+        self.assertFalse(b2mh.represents_number('1a'))
+        self.assertFalse(b2mh.represents_number('a1'))
+        self.assertFalse(b2mh.represents_number('1 + 1'))
+        self.assertFalse(b2mh.represents_number('1+1'))
+        self.assertFalse(b2mh.represents_number(''))
+        self.assertFalse(b2mh.represents_number(' '))
+        self.assertFalse(b2mh.represents_number('\t'))
+        self.assertFalse(b2mh.represents_number('hello world'))
+        self.assertFalse(b2mh.represents_number('.'))
+        self.assertFalse(b2mh.represents_number('+'))
+        self.assertFalse(b2mh.represents_number('-'))
+        
+        self.assertTrue(b2mh.represents_number('inf'))
+        self.assertFalse(b2mh.represents_number(None))
+        self.assertFalse(b2mh.represents_number(dict()))
+        self.assertFalse(b2mh.represents_number(list()))
+        self.assertFalse(b2mh.represents_number([5]))
+        self.assertFalse(b2mh.represents_number([5, 6]))
+        self.assertFalse(b2mh.represents_number(['5']))
+        self.assertFalse(b2mh.represents_number({'a':5}))
+        self.assertFalse(b2mh.represents_number({5:5}))
+        self.assertFalse(b2mh.represents_number({5:'a'}))
+    
+    def test_represents_int(self):
+        self.assertTrue(b2mh.represents_int(5))
+        self.assertTrue(b2mh.represents_int(0))
+        self.assertTrue(b2mh.represents_int(-5))
+        self.assertTrue(b2mh.represents_int('5'))
+        self.assertTrue(b2mh.represents_int('0'))
+        self.assertTrue(b2mh.represents_int('-5'))
+        self.assertTrue(b2mh.represents_int('+5'))
+        
+        self.assertFalse(b2mh.represents_int(5.0))
+        self.assertFalse(b2mh.represents_int(0.0))
+        self.assertFalse(b2mh.represents_int(-5.0))
+        self.assertFalse(b2mh.represents_int('5.0'))
+        self.assertFalse(b2mh.represents_int('0.0'))
+        self.assertFalse(b2mh.represents_int('-5.0'))
+        self.assertFalse(b2mh.represents_int('+5.0'))
+        
+        self.assertFalse(b2mh.represents_int(5.2))
+        self.assertFalse(b2mh.represents_int(0.2))
+        self.assertFalse(b2mh.represents_int(-5.2))
+        self.assertFalse(b2mh.represents_int('5.2'))
+        self.assertFalse(b2mh.represents_int('0.2'))
+        self.assertFalse(b2mh.represents_int('-5.2'))
+        self.assertFalse(b2mh.represents_int('+5.2'))
+        
+        self.assertFalse(b2mh.represents_int('a'))
+        self.assertFalse(b2mh.represents_int('1a'))
+        self.assertFalse(b2mh.represents_int('a1'))
+        self.assertFalse(b2mh.represents_int('1 + 1'))
+        self.assertFalse(b2mh.represents_int('1+1'))
+        self.assertFalse(b2mh.represents_int(''))
+        self.assertFalse(b2mh.represents_int(' '))
+        self.assertFalse(b2mh.represents_int('\t'))
+        self.assertFalse(b2mh.represents_int('hello world'))
+        self.assertFalse(b2mh.represents_int('.'))
+        self.assertFalse(b2mh.represents_int('+'))
+        self.assertFalse(b2mh.represents_int('-'))
+        
+        self.assertFalse(b2mh.represents_int('inf'))
+        self.assertFalse(b2mh.represents_int(None))
+        self.assertFalse(b2mh.represents_int(dict()))
+        self.assertFalse(b2mh.represents_int(list()))
+        self.assertFalse(b2mh.represents_int([5]))
+        self.assertFalse(b2mh.represents_int([5, 6]))
+        self.assertFalse(b2mh.represents_int(['5']))
+        self.assertFalse(b2mh.represents_int({'a':5}))
+        self.assertFalse(b2mh.represents_int({5:5}))
+        self.assertFalse(b2mh.represents_int({5:'a'}))
+    
+    def test_make_pretty_stat_dict(self):
+        test_dict = {
+                'a' : '1234567',
+                'b' : '0.123456',
+                'c' : '1',
+                'd' : '0',
+                'e' : '1.0',
+                'f' : '0.0',
+                'g' : 1234567,
+                'h' : 0.123456,
+                'i' : 1,
+                'j' : 0,
+                'k' : 1.0,
+                'l' : 0.0,
+                'm' : 'abcd',
+                'n' : None,
+                'o' : '',
+                'p' : dict(),
+                'q' : list(),
+                'r' : '+12345',
+                's' : '+1.23456',
+                't' : -1,
+                'u' : -1.0,
+                'v' : '-1.0',
+                'w' : '-0.12345',
+                'x' : '-0.0',
+                'y' : '-0',
+                'z' : -0
+            }
+        answer_dict = {
+                'a' : '1,234,567',
+                'b' : '12.35%',
+                'c' : '1',
+                'd' : '0',
+                'e' : '100.0%',
+                'f' : '0.0%',
+                'g' : '1,234,567',
+                'h' : '12.35%',
+                'i' : '1',
+                'j' : '0',
+                'k' : '100.0%',
+                'l' : '0.0%',
+                'm' : 'abcd',
+                'n' : None,
+                'o' : '',
+                'p' : dict(),
+                'q' : list(),
+                'r' : '12,345',
+                's' : '123.46%',
+                't' : '-1',
+                'u' : '-100.0%',
+                'v' : '-100.0%',
+                'w' : '-12.35%',
+                'x' : '0.0%',
+                'y' : '0',
+                'z' : '0'
+            }
+        pretty_dict = b2mh.make_pretty_stat_dict(test_dict)
+        self.assertEqual(sorted(test_dict.keys()), sorted(pretty_dict.keys()))
+        self.assertEqual(sorted(pretty_dict.keys()), sorted(answer_dict.keys()))
+        for k in pretty_dict:
+            self.assertEqual(pretty_dict[k], answer_dict[k],
+                             'Key: {0}, Got {1}, Answer {2}'.format(k, pretty_dict[k], answer_dict[k]))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add functions to make numbers in report prettier: commas in ints, floats to percents. Only affects reporting layer -- underlying datastructures unchanged. Includes unit tests.